### PR TITLE
Ajout de repartition_normale et tirage_normale (par dichotomie)

### DIFF
--- a/pydiderotlibs/arithmetique.py
+++ b/pydiderotlibs/arithmetique.py
@@ -59,7 +59,6 @@ def bezout(a,b):
     u0, v0 = 1, 0
     u1, v1 = 0, 1
     while r1:
-        print(u0 * a + v0 * b)
         q = r0 // r1
         u0, u1 = u1, u0 - q*u1
         v0, v1 = v1, v0 - q*v1

--- a/pydiderotlibs/arithmetique.py
+++ b/pydiderotlibs/arithmetique.py
@@ -43,3 +43,43 @@ def quotient(a, b):
         b (int): Un nombre entier non nul.
     """
     return a // b
+
+
+def bezout(a,b):
+    """Renvoie un triplet d'entiers (d,u,v) tel que u*a + b*v = d = pgcd(a,b).
+
+    Arguments:
+        a (int) : un nombre entier
+        b (int) : un nombre entier
+    """
+    if b == 0 and a == 0 :
+        raise ZeroDivisionError(
+            "Le PGCD de deux nombres nuls n'existe pas")
+    r0 , r1 = a, b
+    u0, v0 = 1, 0
+    u1, v1 = 0, 1
+    while r1:
+        print(u0 * a + v0 * b)
+        q = r0 // r1
+        u0, u1 = u1, u0 - q*u1
+        v0, v1 = v1, v0 - q*v1
+        r0, r1 = r1, r0 - q*r1
+    return(r0,u0,v0)
+
+
+def puissance_mod(n,p,m):
+    """Renvoie n^p modulo m.
+    
+    Arguments:
+        n (int) : un nombre entier
+        p (int) : un nombre entier
+        m (int) : un nombre entier   
+    """
+    p_bin = bin(p)[-1:1:-1]
+    res = 1
+    carres = n % m
+    for exposant in p_bin:
+        if exposant == '1':
+            res = (res * carres) %  m 
+        carres = (carres ** 2) % m
+    return res   

--- a/pydiderotlibs/stats_proba.py
+++ b/pydiderotlibs/stats_proba.py
@@ -130,7 +130,7 @@ def repartition_normale(x, mu=0, sigma=1):
     return (1 + ferx) / 2
 
 
-def tirage_normale(mu, sigma):
+def tirage_normale(mu, sigma, precision=15):
     """
     Renvoie un nombre décimal (float) choisi de manière aléatoire
     selon une loi nomale d'espérance ``mu`` et d'écart type ``sigma``.
@@ -159,12 +159,11 @@ def tirage_normale(mu, sigma):
     while repartition_normale(b, mu, sigma) < cible:
         a, b = b, b + sigma     
 
-    #On fixe une précision pour la recherche ici, mais ça pourrait être un 
-    #paramètre de la fonction.
-    precision = 1/2**15
+    #On calcule la précision ici
+    epsilon = 1/2**precision
     
     #On applique l'algorithme de dichotomie
-    while repartition_normale(b,mu,sigma) - cible > precision:
+    while repartition_normale(b,mu,sigma) - cible > epsilon:
         milieu = (a+b)/2
         if repartition_normale(milieu, mu, sigma) > cible:
             b = milieu

--- a/pydiderotlibs/stats_proba.py
+++ b/pydiderotlibs/stats_proba.py
@@ -19,6 +19,8 @@ import builtins
 import random
 from .arithmetique import quotient
 from .listes import transposer
+
+
 def binomial(n, p):
     """
     Renvoie un entier (int) représentant le coefficient binomial ``p`` parmi ``n``.
@@ -112,6 +114,22 @@ def tirage_expo(x):
 # Loi normale
 
 
+def repartition_normale(x, mu=0, sigma=1):
+    """
+    Renvoie la probabilité P(y < x) pour P loi normale de moyenne mu et 
+    d'écart type sigma.
+    
+    Arguments:
+        x (float)
+        mu (float): Un nombre décimal. L'éspérance de la loi normale
+        sigma (float): Un nombre décimal. L'écart type de la loi normale        
+    """
+    if sigma <= 0:
+        raise ValueError("Veuillez entrer un écart type strictement positif")
+    ferx = math.erf((x - mu)/(sigma * 2 ** 0.5))
+    return (1 + ferx) / 2
+
+
 def tirage_normale(mu, sigma):
     """
     Renvoie un nombre décimal (float) choisi de manière aléatoire
@@ -121,14 +139,48 @@ def tirage_normale(mu, sigma):
         mu (float): Un nombre décimal. L'éspérance de la loi normale
         sigma (float): Un nombre décimal. L'écart type de la loi normale
     """
-    return random.gauss(mu, sigma)
 
+    cible = random.random() 
+    a = mu 
+    
+    
+    #On symétrise le problème de recherche d'inverse, car si on procède par 
+    #dichotomie, les valeurs très inférieures à la moyenne s'envoient sur des
+    #point très proches et on a un souci de précision.
+    sym = False
+    if cible < 0.5:
+        cible = 1 - cible
+        sym = True
+    
+    #On commence par chercher un intervalle qui contient l'inverse de 'cible'
+    #pour la fonction de répartition. On prends des intervalles de longueur
+    # l'écart-type pour être sûr de trouver en très peu d'itérations
+    b = sigma
+    while repartition_normale(b, mu, sigma) < cible:
+        a, b = b, b + sigma     
 
+    #On fixe une précision pour la recherche ici, mais ça pourrait être un 
+    #paramètre de la fonction.
+    precision = 1/2**15
+    
+    #On applique l'algorithme de dichotomie
+    while repartition_normale(b,mu,sigma) - cible > precision:
+        milieu = (a+b)/2
+        if repartition_normale(milieu, mu, sigma) > cible:
+            b = milieu
+        else:
+            a = milieu
+    
+    #Au besoin, on symétrise autour de la moyenne
+    if sym:
+        return - b + 2 * mu
+    else:
+        return b
+    
 def tirage_gauss(mu, sigma):
     """
     Renvoie un nombre décimal (float) choisi de manière aléatoire
     selon une loi nomale d'espérance ``mu`` et d'écart type ``sigma``.
-
     Arguments:
         mu (float): Un nombre décimal. L'éspérance de la loi normale
         sigma (float): Un nombre décimal. L'écart type de la loi normale


### PR DESCRIPTION
J'ai modifié la fonction tirage_normale afin d'avoir un tirage manuel, en prenant l'inverse de la fonction de répartition. Plusieurs remarques:
1. Je calcule la fonction de répartition en appelant la fonction  d'erreur de la loi normale math.erf. Ça pourrait aussi se faire à la main (développement en série entière puis calcul par la méthode de Horner) si on veut s'amuser.
2. Comme la fonction de répartition de la loi normale n'est pas facilement inversible, je fais une recherche par dichotomie. Y a peut-être mieux à faire mais ça a l'air de marcher raisonnablement bien et rapidement.
3. Petite subtilité pour la dichotomie : essayer d'inverser les points inférieurs à 0.5 (donc d'antécédents sous la moyenne) ça foire pas mal (la courbe en cloche écrase les petits points très violemment...) du coup si je pioche un point p inférieur à 0.5 par loi uniforme, je calcule l'inverse de 1-p puis je prends le symétrique de ce point par rapport à la moyenne.
4. J'ai laissé la fonction tirage_gauss pour toujours avoir une fonction qui fait appel a math.gauss